### PR TITLE
From then() to async/await

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -1,16 +1,18 @@
 const fs = require('fs');
-const request = require('request');
+const fetch = require('node-fetch');
 
-function downloadImage(url, localPath) {
-    return new Promise((resolve, reject) => {
-        request.head(url, function (err) {
-            if (err) {
-                reject(err);
-            }
+async function downloadImage(url, localPath) {
+    try {
+        await fetch(url, { method: 'HEAD' });
+    } catch (err) {
+        throw err;
+    }
 
-            request(url).pipe(fs.createWriteStream(localPath)).on('close', () => resolve(localPath));
-        });
-    });
+    const response = await fetch(url);
+
+    return await new Promise(resolve => response.body
+        .pipe(fs.createWriteStream(localPath))
+        .on('close', resolve(localPath)));
 }
 
 module.exports = downloadImage;

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const cheerio = require('cheerio');
 const yaml = require('js-yaml');
 const url = require('url');
-const request = require('request');
+const fetch = require('node-fetch');
 
 const frontMatterTemplate = {
     title: "",
@@ -39,33 +39,35 @@ var readAll = function (filePath, frontMatterConfig) {
     return { html, frontMatter };
 }
 
-var readFromUrl = function (postUrl) {
-    return new Promise((resolve, reject) => {
-        request.get(postUrl, function (error, response, body) {
-            if (error) {
-                reject(error);
-            }
+var readFromUrl = async function (postUrl) {
+    try {
+        const response = await fetch(postUrl);
+        const body = await response.text();
 
-            let $ = cheerio.load(response.body);
-            $('.section-divider').remove();
+        const $ = cheerio.load(body);
 
-            const html = $('.postArticle-content').html() || '';
+        $('.section-divider').remove();
 
-            const title = $(".graf--title").text();
-            const subtitle = $("meta[name='description']").attr("content");
-            const date = $("meta[property='article:published_time']").attr("content");
-            const canonical = $("link[rel='canonical']").attr("href");
-            const slug = canonical ? url.parse(canonical).path : '';
+        const html = $('.postArticle-content').html() || '';
+        const title = $(".graf--title").text();
+        const subtitle = $("meta[name='description']").attr("content");
+        const date = $("meta[property='article:published_time']").attr("content");
+        const canonical = $("link[rel='canonical']").attr("href");
+        const slug = canonical ? url.parse(canonical).path : '';
 
-            const tags = [];
-            $(".js-postTags li").each((i, e) => {
-                tags.push($(e).text());
-            });
+        const tags = [];
+        $(".js-postTags li").each((i, e) => tags.push($(e).text()));
 
-            const frontMatter = generateFrontMatter(title, subtitle, date, slug, tags);
-            resolve({ html, frontMatter, title });
-        });
-    });
+        const frontMatter = generateFrontMatter(title, subtitle, date, slug, tags);
+
+        return {
+            html,
+            title,
+            frontMatter,
+        };
+    } catch (error) {
+        throw error;
+    }
 }
 
 var generateFrontMatter = function (title, subtitle, date, slug, tags) {

--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -59,7 +59,7 @@ var processAll = function (inputDir, options) {
     }
 }
 
-var processSingle = function (postUrl, options) {
+var processSingle = async function (postUrl, options) {
     try {
         const outputDir = path.normalize(options.outputDir);
         if (!fs.existsSync(outputDir)) {
@@ -67,31 +67,30 @@ var processSingle = function (postUrl, options) {
         }
 
         if (postUrl && utils.isUrl(postUrl)) {
-            read.readFromUrl(postUrl).then(async readOutput => {
-                const converterResult = convert(readOutput.html, options.images);
-                if (options.images === true) {
-                    const imgDir = path.join(outputDir, 'img');
-                    if (!fs.existsSync(imgDir)) {
-                        fs.mkdirSync(imgDir);
-                    }
+            const readOutput = await read.readFromUrl(postUrl);
 
-                    const promises = [];
-
-                    converterResult.images.forEach((v) => {
-                        const localImgPath = path.join(imgDir, v.name);
-                        promises.push(downloader(v.src, localImgPath));
-                    });
-
-                    await Promise.all(promises);
+            const converterResult = convert(readOutput.html, options.images);
+            if (options.images === true) {
+                const imgDir = path.join(outputDir, 'img');
+                if (!fs.existsSync(imgDir)) {
+                    fs.mkdirSync(imgDir);
                 }
 
-                const data = mergeOutputs(readOutput, converterResult.md, options.frontMatter);
+                const promises = [];
 
-                const fileName = utils.getFileNameFromUrl(postUrl);
-                const outputFile = write(outputDir, fileName, data);
+                converterResult.images.forEach((v) => {
+                    const localImgPath = path.join(imgDir, v.name);
+                    promises.push(downloader(v.src, localImgPath));
+                });
 
-                console.log('Completed: ' + outputFile);
-            });
+                await Promise.all(promises);
+            }
+            const data = mergeOutputs(readOutput, converterResult.md, options.frontMatter);
+
+            const fileName = utils.getFileNameFromUrl(postUrl);
+            const outputFile = write(outputDir, fileName, data);
+
+            console.log('Completed: ' + outputFile);
         }
     } catch (err) {
         console.log(err.message);

--- a/package-lock.json
+++ b/package-lock.json
@@ -547,6 +547,11 @@
         "mime-db": "~1.37.0"
       }
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "nth-check": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "cheerio": "^1.0.0-rc.2",
     "commander": "^2.20.0",
     "js-yaml": "^3.13.1",
+    "node-fetch": "~2.6.0",
     "request": "^2.88.0",
     "turndown": "^5.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "commander": "^2.20.0",
     "js-yaml": "^3.13.1",
     "node-fetch": "~2.6.0",
-    "request": "^2.88.0",
     "turndown": "^5.0.3"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -76,4 +76,4 @@ This package uses:
 1. [cheerio](https://github.com/cheeriojs/cheerio) - to select and extract relevant html attributes from Medium posts' html files.
 1. [commander](https://github.com/tj/commander.js) - to enable command line interface.
 1. [js-yaml](https://github.com/nodeca/js-yaml) - to add yaml front matter to markdown files.
-1. [request](https://github.com/request/request) - to get Medium post body from its url.
+1. [node-fetch](https://github.com/bitinn/node-fetch) - to get Medium post body from its url.


### PR DESCRIPTION
This PR allow using `async/await` as much as possible.

To achieve this, it requires going from [request](https://www.npmjs.com/package/request) (which does not support Promises) to a Promises compatible module. `request` does have a Promise equivalent as [request-promise-native](https://www.npmjs.com/package/request-promise-native), but is far less popular than [node-fetch](https://www.npmjs.com/package/node-fetch) which replicate browser fetch API.