### PR TITLE
Header image option

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ program
     .option('-d, --drafts', 'Convert drafts too.')
     .option('-f, --frontMatter', 'Add front-matter.')
     .option('-i, --images', 'Download images in local directory.')
-    .option('-h', '--headerImage', 'Extract header image and add it to the frontMatter')
+    .option('-h, --headerImage', 'Extract header image and add it to the frontMatter')
     .action(workflow.processAll);
 
 program
@@ -22,6 +22,7 @@ program
     .option('-o, --outputDir <>', 'Output directory path.')
     .option('-f, --frontMatter', 'Add front-matter.')
     .option('-i, --images', 'Download images in local directory.')
+    .option('-h, --headerImage', 'Extract header image and add it to the frontMatter')
     .action(workflow.processSingle);
 
 program.parse(process.argv);

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ program
     .option('-d, --drafts', 'Convert drafts too.')
     .option('-f, --frontMatter', 'Add front-matter.')
     .option('-i, --images', 'Download images in local directory.')
+    .option('-h', '--headerImage', 'Extract header image and add it to the frontMatter')
     .action(workflow.processAll);
 
 program

--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -16,6 +16,10 @@ var processAll = function (inputDir, options) {
             fs.mkdirSync(outputPath);
         }
 
+        if(options.headerImage && !(options.frontMatter && options.images)) {
+            throw new Error("The headerImage option -h must be used in conjuction with the frontMatter -f and the images -i option");
+        }
+
         if (options.images === true) {
             if (!fs.existsSync(imgDir)) {
                 fs.mkdirSync(imgDir);

--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -32,14 +32,25 @@ var processAll = function (inputDir, options) {
                             if (options.images === true) {
                                 const promises = [];
 
-                                converterResult.images.forEach((v) => {
+                                converterResult.images.forEach((v, i) => {
                                     const localImgPath = path.join(imgDir, v.name);
                                     promises.push(downloader(v.src, localImgPath));
+
+                                    // This handles situations where a header image has been used. 
+                                    // It extracts it from the body and adds it to the frontMatter. 
+                                    if(i === 0 && options.headerImage && converterResult.md.startsWith("![]")) {
+
+                                        // adding a header image as a variable on the frontMatter
+                                        readOutput.frontMatter += "image: " + localImgPath + "\n";
+
+                                        // remove the first image from the markdown counverterResult
+                                        // the md converter by default converts header images into an image in the beginning of the body
+                                        converterResult.md = converterResult.md.split("\n").slice(1).join("\n");
+                                    }
                                 });
 
                                 await Promise.all(promises);
                             }
-
                             const data = mergeOutputs(readOutput, converterResult.md, options.frontMatter);
                             const fileName = write(outputPath, path.parse(file).name, data);
                             console.log('Completed: ' + fileName);
@@ -64,6 +75,10 @@ var processSingle = function (postUrl, options) {
         const outputDir = path.normalize(options.outputDir);
         if (!fs.existsSync(outputDir)) {
             throw new Error('Invalid output path.');
+        }
+
+        if(options.headerImage && !(options.frontMatter && options.images)) {
+            throw new Error("The headerImage option -h must be used in conjuction with the frontMatter -f and the images -i option");
         }
 
         if (postUrl && utils.isUrl(postUrl)) {

--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -42,6 +42,7 @@ var processAll = function (inputDir, options) {
 
                                     // This handles situations where a header image has been used. 
                                     // It extracts it from the body and adds it to the frontMatter. 
+
                                     if(i === 0 && options.headerImage && converterResult.md.startsWith("![]")) {
 
                                         // adding a header image as a variable on the frontMatter


### PR DESCRIPTION
A number of Hugo themes rely on an `image` variable to be set on the frontMatter in order to designate an image as a header image for a particular post.

This PR adds a `--headerImage` (or `-h`) option to medium-2-md. 

Basically, it seems like the html-to-markdown library that this utility uses extracts the medium header images into an image markdown tag at the beginning of the body of the post. 

If the `--headerImage` flag is set, this takes it from the body and adds it to the frontMatter as an `[image]: /img/imagefile.jpg`. 