### PR TITLE
Fix hardcoded array position for image URL

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -28,7 +28,9 @@ td.addRule('figure', {
         // Need to find a better way to do this!
 
         const lines = content.split('\n');
-        let element = lines[2];
+        const imageStr = "![](https://cdn-images"
+        const imageIndex = lines.findIndex((el)=>{return el.includes(imageStr) });
+        let element = lines[imageIndex];
 
         if (downloadImages === true) {
             const imgSrc = element.substring(4, element.length - 1);


### PR DESCRIPTION
The hard coded array position appears to have changed on Medium. This will dynamically select the correct array position.