### PR TITLE
Fix issues with undefined variables

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -32,7 +32,7 @@ td.addRule('figure', {
         const imageIndex = lines.findIndex((el)=>{return el.includes(imageStr) });
         let element = lines[imageIndex];
 
-        if (downloadImages === true) {
+        if (downloadImages === true && element) {
             const imgSrc = element.substring(4, element.length - 1);
 
             // This check is important as Medium renders embeds (YouTube, etc.) also as figures.
@@ -51,7 +51,7 @@ td.addRule('figure', {
             element = [element.slice(0, 2), lines[4], element.slice(2)].join('');
         }
 
-        return element + '\n' + lines[4];
+        return (element || '') + '\n' + (lines[4] || '');
     }
 })
 

--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -31,13 +31,11 @@ var processAll = function (inputDir, options) {
                             const converterResult = convert(readOutput.html, options.images);
                             if (options.images === true) {
                                 const promises = [];
-
-                                converterResult.images.forEach((v) => {
+                                
+                                for(const v of converterResult.images) {
                                     const localImgPath = path.join(imgDir, v.name);
-                                    promises.push(downloader(v.src, localImgPath));
-                                });
-
-                                await Promise.all(promises);
+                                    await downloader(v.src, localImgPath);
+                                }
                             }
 
                             const data = mergeOutputs(readOutput, converterResult.md, options.frontMatter);


### PR DESCRIPTION
I ran into a couple of bugs recently:
- imageIndex was -1 and element was undefined so the call to `substring` failed
- I kept getting `undefined` output in my md files

This PR puts up some guards to prevent that.