### PR TITLE
Download images sequentially

### DIFF
--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -30,14 +30,10 @@ var processAll = function (inputDir, options) {
                             const readOutput = read.readAll(path.join(inputDir, file), options.frontMatter);
                             const converterResult = convert(readOutput.html, options.images);
                             if (options.images === true) {
-                                const promises = [];
-
-                                converterResult.images.forEach((v) => {
+                                for(const v of converterResult.images) {
                                     const localImgPath = path.join(imgDir, v.name);
-                                    promises.push(downloader(v.src, localImgPath));
-                                });
-
-                                await Promise.all(promises);
+                                    await downloader(v.src, localImgPath);
+                                }
                             }
 
                             const data = mergeOutputs(readOutput, converterResult.md, options.frontMatter);


### PR DESCRIPTION
When there are many posts and many images per post, it can result in connection timeouts. This is due to using `Promise.all` and attempting to fetch all the images at the same time. This PR changes the processing to be sequential. Fixes #9 