### PR TITLE
Add User-Agent header to downloader

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -2,9 +2,11 @@ const fs = require("fs");
 const fetch = require("node-fetch");
 
 async function downloadImage(url, localPath) {
-  await fetch(url, { method: "HEAD" });
-
-  const response = await fetch(url);
+  const response = await fetch(url,  {
+    headers: {
+      'user-agent': 'medium-2-md'
+    }
+  });
 
   return await new Promise((resolve) =>
     response.body


### PR DESCRIPTION
Fixes #26 cc @drewkhoury

💡 _To give a little bit of context_ -> Medium apparently returns `403 Forbidden` for requests without `User-Agent` header.