### PR TITLE
Add timeout flag closes #35

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ program
   .option("-d, --drafts", "Convert drafts too.")
   .option("-f, --frontMatter", "Add front-matter.")
   .option("-i, --images", "Download images at default path.")
+  .option("-t, --timeout <milliseconds>", "Timeout between image downloads in milliseconds (default: 100).")
   .option("-op, --path <path>", "Custom path for saving markdown files.")
   .option("-ip, --img-path <imgpath>", "Custom path for downloading images.")
   .action(workflow.processAll);

--- a/lib/workflow.js
+++ b/lib/workflow.js
@@ -43,6 +43,15 @@ var processAll = function (inputDir, options) {
       fs.mkdirSync(imgDir);
     }
 
+    let timeout = 100; // default timeout
+    if (options.timeout) {
+      timeout = Number(options.timeout);
+      if (isNaN(timeout)) {
+        console.log("Invalid timeout value. Using default timeout.");
+        timeout = 100;
+      }
+    }
+
     if (fs.existsSync(inputPath)) {
       fs.readdirSync(inputPath).forEach(async (file) => {
         try {
@@ -57,6 +66,7 @@ var processAll = function (inputDir, options) {
                 for (const v of converterResult.images) {
                   const localImgPath = path.join(imgDir, v.name);
                   await downloader(v.src, localImgPath);
+                  await new Promise(resolve => setTimeout(resolve, timeout));
                 }
               }
 

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@ The `convertLocal` command supports the following optional flags,
 
 1. `-f` or `--frontMatter`: Add the front matter on top of the markdown files.
 1. `-i` or `--images`: Download images to a local `img` sub-directory.
+1. `-t` or `--timeout`: Set the timeout for downloading images. Default is 100ms.
 1. `-op` or `--path`: Custom path for saving markdown files.
 1. `-ip` or `--img-path`: Custom path for downloading images.
 1. `-d` or `--drafts`: Convert the drafts too.


### PR DESCRIPTION
See issue description for more context: https://github.com/gautamdhameja/medium-2-md/issues/35

Adds a timeout flag such that we don't trigger Medium rate limits.